### PR TITLE
Adds accelerometer data hadling

### DIFF
--- a/arch/esp32/esp32.ini
+++ b/arch/esp32/esp32.ini
@@ -1,7 +1,8 @@
 ; Common settings for ESP targes, mixin with extends = esp32_base
 [esp32_base]
 extends = arduino_base
-platform = platformio/espressif32@^6.2.0
+#platform = platformio/espressif32@^6.2.0
+platform = https://github.com/tasmota/platform-espressif32/releases/download/2023.05.02/platform-espressif32.zip
 
 build_src_filter = 
   ${arduino_base.build_src_filter} -<platform/nrf52/> -<platform/stm32wl> -<platform/rp2040> -<mesh/eth/>
@@ -17,6 +18,7 @@ board_build.filesystem = littlefs
 # This overrides the BLE logging default of LOG_LEVEL_INFO (1) from: .pio/libdeps/tbeam/NimBLE-Arduino/src/esp_nimble_cfg.h
 build_flags =
   ${arduino_base.build_flags}
+  -fexceptions
   -Wall
   -Wextra
   -Isrc/platform/esp32

--- a/src/AccelerometerThread.h
+++ b/src/AccelerometerThread.h
@@ -227,10 +227,9 @@ class AccelerometerThread : public concurrency::OSThread
         report_counter_ = 0;
 
         string timestamp;
-        const uint64_t rtc_sec = getValidTime(RTCQuality::RTCQualityDevice);
-        static constexpr uint64_t millis_in_second{1000};
+        const uint32_t rtc_sec = getValidTime(RTCQuality::RTCQualityDevice);
         if (rtc_sec > 0) {
-            timestamp = to_string(rtc_sec * millis_in_second + millis());
+            timestamp = to_string(rtc_sec);
         } else {
             timestamp = "\"undefined\"";
         }

--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -88,9 +88,9 @@ size_t RedirectablePrint::log(const char *logLevel, const char *format, ...)
                 int min = (hms % SEC_PER_HOUR) / SEC_PER_MIN;
                 int sec = (hms % SEC_PER_HOUR) % SEC_PER_MIN; // or hms % SEC_PER_MIN
 
-                r += printf("%s | %02d:%02d:%02d %u ", logLevel, hour, min, sec, millis() / 1000);
+                r += printf("%s | %02d:%02d:%02d %u ", logLevel, hour, min, sec, millis() % 1000);
             } else
-                r += printf("%s | ??:??:?? %u ", logLevel, millis() / 1000);
+                r += printf("%s | ??:??:?? %u ", logLevel, millis() % 1000);
 
             auto thread = concurrency::OSThread::currentThread;
             if (thread) {

--- a/src/mqtt/MQTT.h
+++ b/src/mqtt/MQTT.h
@@ -61,6 +61,11 @@ class MQTT : private concurrency::OSThread
 
     bool connected();
 
+    // A wrapper for publishing not only Meshtastic but any deliberate text message to mqtt
+    bool debugPublish(const char* topic, const char* payload) {
+      return pubSub.publish(topic, payload);
+    }
+
   protected:
     PointerQueue<meshtastic_ServiceEnvelope> mqttQueue;
 

--- a/variants/tbeam-pipboy/platformio.ini
+++ b/variants/tbeam-pipboy/platformio.ini
@@ -1,0 +1,10 @@
+; The 1.0 release of the TBEAM board 
+[env:tbeam-pipboy]
+extends = esp32_base
+board = ttgo-t-beam
+lib_deps =
+  ${esp32_base.lib_deps}
+build_flags = 
+  ${esp32_base.build_flags} -D TBEAM_V10  -I variants/tbeam-pipboy
+  -DGPS_POWER_TOGGLE ; comment this line to disable double press function on the user button to turn off gps entirely.
+upload_speed = 921600

--- a/variants/tbeam-pipboy/variant.h
+++ b/variants/tbeam-pipboy/variant.h
@@ -3,6 +3,9 @@
 #define I2C_SDA 21
 #define I2C_SCL 22
 
+#define I2C_SDA1 4 // 13
+#define I2C_SCL1 0 // 14
+
 #define BUTTON_PIN 38 // The middle button GPIO on the T-Beam
 //#define BUTTON_PIN_ALT 13 // Alternate GPIO for an external button if needed. Does anyone use this? It is not documented
 // anywhere.

--- a/variants/tbeam/variant.h
+++ b/variants/tbeam/variant.h
@@ -3,6 +3,9 @@
 #define I2C_SDA 21
 #define I2C_SCL 22
 
+#define I2C_SDA1 13
+#define I2C_SCL1 14
+
 #define BUTTON_PIN 38 // The middle button GPIO on the T-Beam
 //#define BUTTON_PIN_ALT 13 // Alternate GPIO for an external button if needed. Does anyone use this? It is not documented
 // anywhere.


### PR DESCRIPTION
* Enables I2C 2 on pins 13,14 (or 4,0)
* Adds reporting acceleration values to the console
* Fixes typo in accelerometer_type variable name

To activate Accelerometer thread, please set either of two settings: config.display.wake_on_tap_or_motion or config.device.double_tap_as_button_press. This is a temporary workaround to ensure the accelerometer thread does not shutdown.
The MPU6050 has to be connected to pins: 14--SCL 13--SDA, +5 and GND respectively. The Wire1 (I2C_1) interface is being remapped to these pins, and the accelerometer thread is hardcoded to use only the Wire1 (instead of Wire) I2C in this PR.

The accelerometer thread reports the accel/rotation/temperature data from the MPU6050 like:

```
INFO  | ??:??:?? 284 [AccelerometerThread] Acceleration: x -0.6800 y -2.9281 z 10.3238, Rotation: yaw 0.0049 pitch 0.0205 roll -0.0453, Temperature: 28.62
```
in console (USB UART)

Known issues: for yet an unknown reason the image on LCD display is a bit corrupted -- a narrow strip of noise on the left side; investigation pending.

UPD: also adds MotionState variable which stores detected motion state: either the object is moving, is still or have been still for a long time.

UPD: adds reporting the accelerometer data to MQTT if available

UPD: adds reporting a changed movement (motion) state to the mesh. To make it work, all the devices must have channel 2 configured, having the same name and sharing the same PSK for channel 2.