### PR TITLE
Sdcard logger

### DIFF
--- a/src/AccelerometerThread.h
+++ b/src/AccelerometerThread.h
@@ -290,8 +290,12 @@ class AccelerometerThread : public concurrency::OSThread
             // if necessary
             topic += "/accelerometer";
             mqtt->debugPublish(topic.c_str(), message.c_str());
+            mqtt_warning_counter_ = 0;
         } else {
-            LOG_DEBUG("MQTT is not connected\n");
+            if (mqtt_warning_counter_++ > mqtt_warning_period_) {
+              LOG_WARN("MQTT is not connected\n");
+              mqtt_warning_counter_ = 0;
+            }
         }
     }
 
@@ -327,6 +331,8 @@ class AccelerometerThread : public concurrency::OSThread
     int report_counter_{0};
     const int reporting_period_{20}; // ~ in 0.1 seconds, empirycally
     Mpu6050DataHandler mpu6050_data_handler_;
+    int mqtt_warning_counter_{0};
+    const int mqtt_warning_period_{20};
 
     const std::string device_name{
             (owner.short_name[0] != '\0') ? owner.short_name : "undefined"};

--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -10,6 +10,11 @@ SPIClass SPI1(HSPI);
 #define SDHandler SPI1
 #endif
 
+#ifdef SDCARD_USE_SPI2
+SPIClass SPI2(HSPI);
+#define SDHandler SPI2
+#endif
+
 #endif // HAS_SDCARD
 
 bool copyFile(const char *from, const char *to)
@@ -183,9 +188,10 @@ void fsInit()
 void setupSDCard()
 {
 #ifdef HAS_SDCARD
-    SDHandler.begin(SPI_SCK, SPI_MISO, SPI_MOSI);
+    SDHandler.begin(SD_SPI_SCLK, SD_SPI_MISO, SD_SPI_MOSI, SD_SPI_CS);
+    pinMode(SD_SPI_CS, OUTPUT);
 
-    if (!SD.begin(SDCARD_CS, SDHandler)) {
+    if (!SD.begin(SD_SPI_CS, SDHandler)) {
         LOG_DEBUG("No SD_MMC card detected\n");
         return;
     }
@@ -205,9 +211,12 @@ void setupSDCard()
         LOG_DEBUG("UNKNOWN\n");
     }
 
-    uint64_t cardSize = SD.cardSize() / (1024 * 1024);
-    LOG_DEBUG("SD Card Size: %lluMB\n", cardSize);
-    LOG_DEBUG("Total space: %llu MB\n", SD.totalBytes() / (1024 * 1024));
-    LOG_DEBUG("Used space: %llu MB\n", SD.usedBytes() / (1024 * 1024));
+    static constexpr uint64_t bytes_in_mb{uint64_t(1024) * 1024};
+    const uint32_t cardSizeMB = static_cast<uint32_t>(SD.cardSize() / bytes_in_mb);
+    const uint32_t totalMegaBytes = static_cast<uint32_t>(SD.totalBytes() / bytes_in_mb);
+    const uint32_t usedMegaBytes = static_cast<uint32_t>(SD.usedBytes() / bytes_in_mb);
+    LOG_DEBUG("SD Card Size: %lu MB\n", cardSizeMB);
+    LOG_DEBUG("Total space: %lu MB\n", totalMegaBytes);
+    LOG_DEBUG("Used space: %lu MB\n", usedMegaBytes);
 #endif
 }

--- a/src/SDCardLogger.cpp
+++ b/src/SDCardLogger.cpp
@@ -1,0 +1,55 @@
+#include "SDCardLogger.h"
+#include "NodeDB.h"
+#include "PowerFSM.h"
+#include "configuration.h"
+
+#ifdef HAS_SDCARD
+#include <FS.h>
+#include <FSCommon.h>
+#include <SD.h>
+#endif
+
+SDCardLogger *sd_card_log_writer{nullptr};
+
+void sdCardLogWriterInit() {
+  // Must be dynamically allocated because we are now inheriting from thread
+#ifdef HAS_SDCARD
+  new SDCardLogger();
+#endif
+}
+
+SDCardLogger::SDCardLogger() : concurrency::OSThread("SDCardLogger") {
+  assert(!sd_card_log_writer);
+  sd_card_log_writer = this;
+
+  setupSDCard();
+
+  if (SD.exists(default_log_filename)) {
+    auto f = SD.open(default_log_filename, FILE_READ);
+    if (f) {
+      LOG_DEBUG("Default log file exists, size: %d\n", f.available());
+    }
+    f.close();
+  }
+}
+
+int32_t SDCardLogger::runOnce() {
+  if (cache_.size() < cache_limit) {
+    return 0;
+  }
+
+  auto logfile = SD.open(default_log_filename, FILE_APPEND);
+  if (logfile) {
+    logfile.write(cache_.data(), cache_.size());
+  }
+  logfile.close();
+
+  cache_.clear();
+
+  LOG_DEBUG("Dumped console log to SD card.\n");
+  return 0;
+}
+
+void SDCardLogger::append(uint8_t c) { cache_.emplace_back(c); }
+
+SDCardLogger::~SDCardLogger() {}

--- a/src/SDCardLogger.h
+++ b/src/SDCardLogger.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <vector>
+
+#include "concurrency/OSThread.h"
+
+namespace fs {
+class File;
+}
+
+void sdCardLogWriterInit();
+
+class SDCardLogger : public concurrency::OSThread {
+public:
+  SDCardLogger();
+  ~SDCardLogger();
+
+  int32_t runOnce() override;
+
+  void append(uint8_t c);
+
+  static constexpr size_t cache_limit{1024};
+  const char *default_log_filename = "/log.txt";
+
+private:
+  std::vector<uint8_t> cache_;
+};
+
+extern SDCardLogger *sd_card_log_writer;

--- a/src/SDCardLogger.h
+++ b/src/SDCardLogger.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <string>
 
 #include "concurrency/OSThread.h"
 
@@ -10,7 +11,10 @@ class File;
 
 void sdCardLogWriterInit();
 
+using std::string;
+
 class SDCardLogger : public concurrency::OSThread {
+
 public:
   SDCardLogger();
   ~SDCardLogger();
@@ -19,11 +23,17 @@ public:
 
   void append(uint8_t c);
 
+  const string& current_log_file_path() const;
+
   static constexpr size_t cache_limit{1024};
-  const char *default_log_filename = "/log.txt";
+  const string log_file_extension = ".log";
+  const string log_folder = "/lifelink/logs/";
+  const string default_name = "default";
 
 private:
   std::vector<uint8_t> cache_;
+  mutable uint32_t last_file_timestamp_{0};
+  mutable string current_path_{log_folder + default_name + log_file_extension};
 };
 
 extern SDCardLogger *sd_card_log_writer;

--- a/src/SerialConsole.cpp
+++ b/src/SerialConsole.cpp
@@ -3,6 +3,14 @@
 #include "PowerFSM.h"
 #include "configuration.h"
 
+#ifdef HAS_SDCARD
+#include <SD.h>
+#include <FS.h>
+#include <FSCommon.h>
+#endif
+
+#include "SDCardLogger.h"
+
 #define Port Serial
 // Defaulting to the formerly removed phone_timeout_secs value of 15 minutes
 #define SERIAL_CONNECTION_TIMEOUT (15 * 60) * 1000UL
@@ -11,7 +19,12 @@ SerialConsole *console;
 
 void consoleInit()
 {
-    new SerialConsole(); // Must be dynamically allocated because we are now inheriting from thread
+  // Must be dynamically allocated because we are now inheriting from thread
+#ifdef HAS_SDCARD
+  new SerialAndFileConsole();
+#else
+  new SerialConsole();
+#endif
 }
 
 void consolePrintf(const char *format, ...)
@@ -77,5 +90,64 @@ bool SerialConsole::handleToRadio(const uint8_t *buf, size_t len)
         return StreamAPI::handleToRadio(buf, len);
     } else {
         return false;
+    }
+}
+
+SerialAndFileConsole::SerialAndFileConsole() : SerialConsole() {}
+
+bool SerialAndFileConsole::tryStartingLogInFile(const char* filepath) {
+    logfile_ = new fs::File();
+    *logfile_ = SD.open(filepath, FILE_APPEND);
+    if (*logfile_) {
+        logfile_->write('#');
+        logfile_->flush();
+        return true;
+    } else {
+        delete logfile_;
+        logfile_ = nullptr;
+    }
+
+    return false;
+}
+
+void SerialAndFileConsole::writeToFileWithCaching(uint8_t c) {
+    /*cache_.emplace_back(c);
+    if (cache_.size() < cache_limit_) {
+        return;
+    }
+    if (not logfile_ or not *logfile_) {
+        SerialConsole::write('\n');
+        SerialConsole::write('\n');
+        if (tryStartingLogInFile("/default_log.txt"))
+            SerialConsole::write('!');
+        else
+            SerialConsole::write('?');
+        SerialConsole::write('\n');
+        SerialConsole::write('\n');
+    } 
+    //auto logfile = SD.open("/default_log.txt", FILE_WRITE, true);
+    if (logfile_ and *logfile_) {
+        logfile_->write(cache_.data(), cache_.size());
+        //logfile_->flush();
+        //logfile.close();
+    }
+    SerialConsole::write('\n');
+    SerialConsole::write('\n');
+    SerialConsole::write('#');
+    SerialConsole::write('\n');
+    
+    
+    cache_.clear();*/
+    if (sd_card_log_writer) {
+        sd_card_log_writer->append(c);
+    }
+}
+
+SerialAndFileConsole::~SerialAndFileConsole() {
+    // TODO: ensure closing the file handle correctly
+    if (logfile_ and *logfile_) {
+        logfile_->close();
+        delete logfile_;
+        logfile_ = nullptr;
     }
 }

--- a/src/SerialConsole.cpp
+++ b/src/SerialConsole.cpp
@@ -4,12 +4,9 @@
 #include "configuration.h"
 
 #ifdef HAS_SDCARD
-#include <SD.h>
-#include <FS.h>
-#include <FSCommon.h>
+#include "SDCardLogger.h"
 #endif
 
-#include "SDCardLogger.h"
 
 #define Port Serial
 // Defaulting to the formerly removed phone_timeout_secs value of 15 minutes
@@ -95,59 +92,10 @@ bool SerialConsole::handleToRadio(const uint8_t *buf, size_t len)
 
 SerialAndFileConsole::SerialAndFileConsole() : SerialConsole() {}
 
-bool SerialAndFileConsole::tryStartingLogInFile(const char* filepath) {
-    logfile_ = new fs::File();
-    *logfile_ = SD.open(filepath, FILE_APPEND);
-    if (*logfile_) {
-        logfile_->write('#');
-        logfile_->flush();
-        return true;
-    } else {
-        delete logfile_;
-        logfile_ = nullptr;
-    }
-
-    return false;
-}
-
 void SerialAndFileConsole::writeToFileWithCaching(uint8_t c) {
-    /*cache_.emplace_back(c);
-    if (cache_.size() < cache_limit_) {
-        return;
-    }
-    if (not logfile_ or not *logfile_) {
-        SerialConsole::write('\n');
-        SerialConsole::write('\n');
-        if (tryStartingLogInFile("/default_log.txt"))
-            SerialConsole::write('!');
-        else
-            SerialConsole::write('?');
-        SerialConsole::write('\n');
-        SerialConsole::write('\n');
-    } 
-    //auto logfile = SD.open("/default_log.txt", FILE_WRITE, true);
-    if (logfile_ and *logfile_) {
-        logfile_->write(cache_.data(), cache_.size());
-        //logfile_->flush();
-        //logfile.close();
-    }
-    SerialConsole::write('\n');
-    SerialConsole::write('\n');
-    SerialConsole::write('#');
-    SerialConsole::write('\n');
-    
-    
-    cache_.clear();*/
+#ifdef HAS_SDCARD
     if (sd_card_log_writer) {
         sd_card_log_writer->append(c);
     }
-}
-
-SerialAndFileConsole::~SerialAndFileConsole() {
-    // TODO: ensure closing the file handle correctly
-    if (logfile_ and *logfile_) {
-        logfile_->close();
-        delete logfile_;
-        logfile_ = nullptr;
-    }
+#endif
 }

--- a/src/SerialConsole.h
+++ b/src/SerialConsole.h
@@ -3,8 +3,6 @@
 #include "RedirectablePrint.h"
 #include "StreamAPI.h"
 
-#include <vector>
-
 /**
  * Provides both debug printing and, if the client starts sending protobufs to us, switches to send/receive protobufs
  * (and starts dropping debug printing - FIXME, eventually those prints should be encapsulated in protobufs).
@@ -24,7 +22,6 @@ class SerialConsole : public StreamAPI, public RedirectablePrint, private concur
     {
         if (c == '\n') // prefix any newlines with carriage return
             RedirectablePrint::write('\r');
-        // TODO: impl. writing to the file handle
         return RedirectablePrint::write(c);
     }
 
@@ -41,10 +38,6 @@ class SerialConsole : public StreamAPI, public RedirectablePrint, private concur
 void consolePrintf(const char *format, ...);
 void consoleInit();
 
-namespace fs {
-class File;
-}
-
 /**
  * Provides both debug printing and, if the client starts sending protobufs to us, switches to send/receive protobufs
  * (and starts dropping debug printing - FIXME, eventually those prints should be encapsulated in protobufs).
@@ -58,21 +51,12 @@ class SerialAndFileConsole : public SerialConsole {
 
     SerialAndFileConsole();
 
-    virtual ~SerialAndFileConsole() override;
-
-    bool tryStartingLogInFile(const char* filepath);
-
     virtual size_t write(uint8_t c) override {
-        // Write to the card here just as well.
         writeToFileWithCaching(c);
         return SerialConsole::write(c);
     }
 
   private:
-    // TODO: file handle
-    fs::File* logfile_{nullptr};
-    std::vector<uint8_t> cache_;
-    static constexpr size_t cache_limit_{300};
     void writeToFileWithCaching(uint8_t c);
 };
 

--- a/src/SerialConsole.h
+++ b/src/SerialConsole.h
@@ -2,6 +2,9 @@
 
 #include "RedirectablePrint.h"
 #include "StreamAPI.h"
+
+#include <vector>
+
 /**
  * Provides both debug printing and, if the client starts sending protobufs to us, switches to send/receive protobufs
  * (and starts dropping debug printing - FIXME, eventually those prints should be encapsulated in protobufs).
@@ -21,6 +24,7 @@ class SerialConsole : public StreamAPI, public RedirectablePrint, private concur
     {
         if (c == '\n') // prefix any newlines with carriage return
             RedirectablePrint::write('\r');
+        // TODO: impl. writing to the file handle
         return RedirectablePrint::write(c);
     }
 
@@ -36,5 +40,40 @@ class SerialConsole : public StreamAPI, public RedirectablePrint, private concur
 // A simple wrapper to allow non class aware code write to the console
 void consolePrintf(const char *format, ...);
 void consoleInit();
+
+namespace fs {
+class File;
+}
+
+/**
+ * Provides both debug printing and, if the client starts sending protobufs to us, switches to send/receive protobufs
+ * (and starts dropping debug printing - FIXME, eventually those prints should be encapsulated in protobufs).
+ */
+class SerialAndFileConsole : public SerialConsole {
+  public:
+    using SerialConsole::checkIsConnected;
+    using SerialConsole::flush;
+    using SerialConsole::handleToRadio;
+    using SerialConsole::runOnce;
+
+    SerialAndFileConsole();
+
+    virtual ~SerialAndFileConsole() override;
+
+    bool tryStartingLogInFile(const char* filepath);
+
+    virtual size_t write(uint8_t c) override {
+        // Write to the card here just as well.
+        writeToFileWithCaching(c);
+        return SerialConsole::write(c);
+    }
+
+  private:
+    // TODO: file handle
+    fs::File* logfile_{nullptr};
+    std::vector<uint8_t> cache_;
+    static constexpr size_t cache_limit_{300};
+    void writeToFileWithCaching(uint8_t c);
+};
 
 extern SerialConsole *console;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,6 +72,10 @@ NRF52Bluetooth *nrf52Bluetooth;
 #include "AccelerometerThread.h"
 #endif
 
+#ifdef HAS_SDCARD
+#include "SDCardLogger.h"
+#endif
+
 using namespace concurrency;
 
 // We always create a screen object, but we only init it if we find the hardware
@@ -384,10 +388,6 @@ void setup()
 
     i2cScanner.reset();
 
-#ifdef HAS_SDCARD
-    setupSDCard();
-#endif
-
 #ifdef RAK4630
     // scanEInkDevice();
 #endif
@@ -453,6 +453,10 @@ void setup()
     // ESP32
     SPI.begin(RF95_SCK, RF95_MISO, RF95_MOSI, RF95_NSS);
     SPI.setFrequency(4000000);
+#endif
+
+#ifdef HAS_SDCARD
+    sdCardLogWriterInit();
 #endif
 
     // Initialize the screen first so we can show the logo while we start up everything else.

--- a/variants/tbeam-lifelink/variant.h
+++ b/variants/tbeam-lifelink/variant.h
@@ -10,7 +10,7 @@
 
 //#define BUTTON_PIN_ALT 13 // Alternate GPIO for an external button if needed. Does anyone use this? It is not documented
 // anywhere.
-//#define EXT_NOTIFY_OUT 35 // 13 // Default pin to use for Ext Notify Module.
+//#define EXT_NOTIFY_OUT 13 // Default pin to use for Ext Notify Module.
 
 #define LED_INVERTED 1
 #define LED_PIN 4 // Newer tbeams (1.1) have an extra led on GPIO4

--- a/variants/tbeam-lifelink/variant.h
+++ b/variants/tbeam-lifelink/variant.h
@@ -6,7 +6,7 @@
 #define I2C_SDA1 4 // 13
 #define I2C_SCL1 0 // 14
 
-#define BUTTON_PIN 35 // 38 // The middle button GPIO on the T-Beam
+#define BUTTON_PIN 15 // 38 // The middle button GPIO on the T-Beam
 
 //#define BUTTON_PIN_ALT 13 // Alternate GPIO for an external button if needed. Does anyone use this? It is not documented
 // anywhere.

--- a/variants/tbeam-lifelink/variant.h
+++ b/variants/tbeam-lifelink/variant.h
@@ -10,21 +10,29 @@
 
 //#define BUTTON_PIN_ALT 13 // Alternate GPIO for an external button if needed. Does anyone use this? It is not documented
 // anywhere.
-#define EXT_NOTIFY_OUT 13 // Default pin to use for Ext Notify Module.
+//#define EXT_NOTIFY_OUT 35 // 13 // Default pin to use for Ext Notify Module.
 
 #define LED_INVERTED 1
 #define LED_PIN 4 // Newer tbeams (1.1) have an extra led on GPIO4
 
+// SDcard is set to use SPI2 (vspi) on pins:
+#define HAS_SDCARD
+#define SDCARD_USE_SPI2
+#define SD_SPI_MISO 13 // 25
+#define SD_SPI_MOSI 14 // 33
+#define SD_SPI_SCLK 25 // 32
+#define SD_SPI_CS 32 // 15 // 33
+
 // TTGO uses a common pinout for their SX1262 vs RF95 modules - both can be enabled and we will probe at runtime for RF95 and if
 // not found then probe for SX1262
 #define USE_RF95 // RFM95/SX127x
-#define USE_SX1262
-#define USE_SX1268
+//#define USE_SX1262
+//#define USE_SX1268
 
 #define LORA_DIO0 26 // a No connect on the SX1262 module
 #define LORA_RESET 23
 #define LORA_DIO1 33 // SX1262 IRQ
-#define LORA_DIO2 32 // SX1262 BUSY
+//#define LORA_DIO2 32 // SX1262 BUSY
 #define LORA_DIO3    // Not connected on PCB, but internally on the TTGO SX1262, if DIO3 is high the TXCO is enabled
 
 #ifdef USE_SX1262


### PR DESCRIPTION
Implements logging all the console output to SD card files.
Each hour, a new log file is started in `/lifelink/logs/` folder, named according to UNIX timestamp in seconds with `.log` extension, such as `1688985553.log`.
If there is no GPS or WIFI time available, the logs are written to `default.log` file.

This PR also demand rewiring the SDCard and the button to some different pins, otherwise the LORA module pinout interferes with SD card pins and its SPI. The HSPI (SPI1) is used to communicate with SD card, pin mapping: see the corresponding `variant.h`.